### PR TITLE
xfig: add a workaround for configuration path

### DIFF
--- a/xfig.rb
+++ b/xfig.rb
@@ -15,9 +15,21 @@ class Xfig < Formula
     ENV.append "LDFLAGS", "-ljpeg"
 
     system "./configure", "--prefix=#{prefix}",
+                          # Because of the shim we'll write alone
+                          "--bindir=#{libexec}",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules"
     system "make", "install"
+
+    # Xfig's X11 config relies on it being installed in a flat prefix,
+    # rather than one like Homebrew's with software installed in different
+    # linked prefixes. This shim script sets XAPPLRESDIR to ensure Xfig can
+    # find its configuration files on startup.
+    (bin/"xfig").write <<~EOS
+      #!/bin/sh
+      export XAPPLRESDIR=#{share}/X11/app-defaults
+      exec "#{libexec}/xfig" "$@"
+    EOS
   end
 
   test do


### PR DESCRIPTION
Xfig can't find its configuration files on startup because Homebrew's path layout clashes with how it expects a Unix prefix to look. I've added a shim script which sets `XAPPLRESDIR` to make sure it can be found.

Fixes #17.
Fixes #13.